### PR TITLE
fixed multiple inclusion and missing exports

### DIFF
--- a/rasoul_promts_pkg/CMakeLists.txt
+++ b/rasoul_promts_pkg/CMakeLists.txt
@@ -111,7 +111,7 @@ link_directories(${BULLET_LIBRARY_DIRS})
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES rasoul_promts_pkg
-#  CATKIN_DEPENDS roscpp
+  CATKIN_DEPENDS rasoul_common_pkg rasoul_visualizer_pkg rasoul_collision_detection_pkg rasoul_geometry_pkg
 #  DEPENDS system_lib
 )
 

--- a/rasoul_promts_pkg/include/rasoul_promts_pkg/PROMTSAstar.hpp
+++ b/rasoul_promts_pkg/include/rasoul_promts_pkg/PROMTSAstar.hpp
@@ -111,7 +111,7 @@ namespace rasoul
     }
 
     // get distance of "this" node to idx-th child node
-    float getDistToChild( unsigned int idx )
+    inline float getDistToChild( unsigned int idx )
     {
       if(idx<m_costFromThisToChild.size())
       {
@@ -121,20 +121,20 @@ namespace rasoul
     }
 
     // get heuristic cost to reach a goal state from "this" node
-    float getHeuristicCostToGoal( AstarNode* goalNodePtr )
+    inline float getHeuristicCostToGoal( AstarNode* goalNodePtr )
     {
       return(m_estimatedCostToGoal);
     }
 
     // is "this" node a goal state?
-    bool isGoal( AstarNode* goalNodePtr )
+    inline bool isGoal( AstarNode* goalNodePtr )
     {
       if(m_isNodeAGoal) return(true);
       return(false);
     }
 
     // compute children and other neccessary computations
-    void compute()
+    inline void compute()
     {
       std::vector< geometry::AABBox<Real> > aabb(m_shapesPtr->size());
       m_estimatedCostToGoal = 0.0f;
@@ -203,7 +203,7 @@ namespace rasoul
     }
 
     // return the solution
-    void getSolution(std::vector<AstarNode*>& solution)
+    inline void getSolution(std::vector<AstarNode*>& solution)
     {
       solution.clear();
       AstarNode* node = this;
@@ -216,7 +216,7 @@ namespace rasoul
     }
 
     // checks if the set of newPoses has been already visited
-    bool isVisited(PoseVector& newPoses)
+    inline bool isVisited(PoseVector& newPoses)
     {
       AstarNode* theparent = m_parentPtr;
       while(theparent)
@@ -236,7 +236,7 @@ namespace rasoul
     }
 
     // print some info about the node
-    void printNodeInfo(COpenGLRosCom* glNodePtr)
+    inline void printNodeInfo(COpenGLRosCom* glNodePtr)
     {
       if(glNodePtr == NULL) return;
       Matrix<float,3,1> color(0.1f, 0.5f, 0.4f);
@@ -269,7 +269,7 @@ namespace rasoul
   };
 
   template<typename CNodeT>
-  CSolution<CNodeT> A_Star_Search(CNodeT* startNodePtr, CNodeT* goalNodePtr, ProblemDataStruct& pds)
+  inline CSolution<CNodeT> A_Star_Search(CNodeT* startNodePtr, CNodeT* goalNodePtr, ProblemDataStruct& pds)
   {
     std::vector<CNodeT*> closedSet; // The set of nodes already evaluated.
     std::vector<CNodeT*> openSet;   // The set of tentative nodes to be evaluated,
@@ -353,7 +353,7 @@ namespace rasoul
     return F;
   }
 
-  bool
+  inline bool
   refinePoses_AStarSearch
   (
     ShapeVector& shapes, // input: Shapes

--- a/rasoul_promts_pkg/include/rasoul_promts_pkg/PROMTSDLS.hpp
+++ b/rasoul_promts_pkg/include/rasoul_promts_pkg/PROMTSDLS.hpp
@@ -98,13 +98,13 @@ namespace rasoul
         delete child[i];
     }
 
-    bool isGoal()
+    inline bool isGoal()
     {
       if(isAtGoal) return(true);
       return(false);
     }
 
-    void Compute()
+    inline void Compute()
     {
       std::vector< geometry::AABBox<Real> > aabb(shapesPtr->size());
       Real total_inter_penetration = 0.0f;
@@ -174,7 +174,7 @@ namespace rasoul
       else if(total_inter_penetration/child.size() < 0.005) isAtGoal = true;
     }
 
-    void getSolution(std::vector<DLSearchNode*>& solution)
+    inline void getSolution(std::vector<DLSearchNode*>& solution)
     {
       solution.clear();
       DLSearchNode* node = this;
@@ -186,7 +186,7 @@ namespace rasoul
       }
     }
 
-    bool isVisited(PoseVector& newPoses)
+    inline bool isVisited(PoseVector& newPoses)
     {
       DLSearchNode* theparent = parent;
       while(theparent)
@@ -205,12 +205,12 @@ namespace rasoul
       return(false);
     }
 
-    Real GetTotalDOP()
+    inline Real GetTotalDOP()
     {
       return total_cost_to_reach_this_node;
     }
 
-    void PrintNodeInfo(COpenGLRosCom* glNodePtr)
+    inline void PrintNodeInfo(COpenGLRosCom* glNodePtr)
     {
       Matrix<Real,3,1> color(0.1f, 0.5f, 0.4f);
       for(unsigned int i=0; i<shapesPtr->size(); i++)
@@ -238,7 +238,7 @@ namespace rasoul
       bool  isAtGoal;
   };
 
-  CSolution<DLSearchNode> RecursiveDLS(DLSearchNode* nodePtr, int limit, ProblemDataStruct& pds)
+  inline CSolution<DLSearchNode> RecursiveDLS(DLSearchNode* nodePtr, int limit, ProblemDataStruct& pds)
   {
     pds.m_iterations++;
 
@@ -270,12 +270,12 @@ namespace rasoul
     }
   }
 
-  CSolution<DLSearchNode> DepthLimitedSearch(DLSearchNode* initNodePtr, int limit, ProblemDataStruct& pds)
+  inline CSolution<DLSearchNode> DepthLimitedSearch(DLSearchNode* initNodePtr, int limit, ProblemDataStruct& pds)
   {
     return RecursiveDLS(initNodePtr, limit, pds);
   }
 
-  bool
+  inline bool
   refinePoses_DLSearch
   (
     ShapeVector& shapes, // input: Shapes

--- a/rasoul_promts_pkg/package.xml
+++ b/rasoul_promts_pkg/package.xml
@@ -46,6 +46,10 @@
   <build_depend>rasoul_visualizer_pkg</build_depend>
   <build_depend>rasoul_collision_detection_pkg</build_depend>
   <build_depend>rasoul_geometry_pkg</build_depend>
+  <run_depend>rasoul_common_pkg</run_depend>
+  <run_depend>rasoul_visualizer_pkg</run_depend>
+  <run_depend>rasoul_collision_detection_pkg</run_depend>
+  <run_depend>rasoul_geometry_pkg</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Since some methods which were implemented inline in the respective headers hadn't been marked as such, multiple inclusion errors would spawn.
Additionally, some dependencies were not exported.
