### PR TITLE
made Bullet usage optional (does not need to be compiled and linked if not used)

### DIFF
--- a/rasoul_geometry_pkg/include/rasoul_geometry_pkg/GeometryPolyhedra.hpp
+++ b/rasoul_geometry_pkg/include/rasoul_geometry_pkg/GeometryPolyhedra.hpp
@@ -54,8 +54,10 @@
 #include "rasoul_geometry_pkg/GeometryVolume.hpp"
 #include "rasoul_geometry_pkg/GeometryCentroid.hpp"
 
+#ifdef PROMTS_USE_BULLET
 #include <LinearMath/btConvexHullComputer.h>
 #include <LinearMath/btTransform.h>
+#endif
 
 #include <Eigen/Eigen>
 
@@ -101,6 +103,7 @@ namespace rasoul{
         //
         ////////////////////////////////////////////////////////////////////////
 
+#ifdef PROMTS_USE_BULLET
         ////////////////////////////////////////////////////////////////////////
         // Compute 3D convex hull - BULLET Implementation
         if(method_type == METHOD_BULLET)
@@ -135,6 +138,7 @@ namespace rasoul{
         }
         //
         ////////////////////////////////////////////////////////////////////////
+#endif
 
         ////////////////////////////////////////////////////////////////////////
         // Compute 3D convex hull - BRUTE FORCE
@@ -227,6 +231,7 @@ namespace rasoul{
         //
         ////////////////////////////////////////////////////////////////////////
 
+#ifdef PROMTS_USE_BULLET
         ////////////////////////////////////////////////////////////////////////
         // Fill in F
         if(method_type == METHOD_BULLET)
@@ -274,6 +279,7 @@ namespace rasoul{
         }
         //
         ////////////////////////////////////////////////////////////////////////
+#endif
 
         ////////////////////////////////////////////////////////////////////////
         // Fill in E
@@ -484,7 +490,9 @@ namespace rasoul{
       T volume;                         // Volume of the polyhedron
     private:
       T epsil;
+#ifdef PROMTS_USE_BULLET
       btConvexHullComputer convexUtil;
+#endif
       std::vector< Matrix<T,3,1> > V_; // Original vertices of the polyhedron
       std::vector< Face<T> > F_;       // Original faces of the polyhedron
       std::vector< Edge<T> > E_;       // Original edges of the polyhedron

--- a/rasoul_promts_pkg/CMakeLists.txt
+++ b/rasoul_promts_pkg/CMakeLists.txt
@@ -15,9 +15,15 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen REQUIRED)
 include_directories(${Eigen_INCLUDE_DIRS})
 
-find_package(Bullet REQUIRED)
-include_directories(${BULLET_INCLUDE_DIRS})
-link_directories(${BULLET_LIBRARY_DIRS})
+SET(PROMTS_USE_BULLET true)
+
+# Bullet, if required
+IF(PROMTS_USE_BULLET)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPROMTS_USE_BULLET")
+    find_package(Bullet REQUIRED)
+    include_directories(${BULLET_INCLUDE_DIRS})
+    link_directories(${BULLET_LIBRARY_DIRS})
+ENDIF(PROMTS_USE_BULLET)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -132,14 +138,26 @@ include_directories(
 # )
 
 add_executable(DemoPROMTSAstar demo/DemoPROMTSAstar.cpp demo/DemoHelper.cpp)
-target_link_libraries(DemoPROMTSAstar
-  ${catkin_LIBRARIES} BulletDynamics  BulletCollision LinearMath
-)
+IF(PROMTS_USE_BULLET)
+    target_link_libraries(DemoPROMTSAstar
+      ${catkin_LIBRARIES} BulletDynamics  BulletCollision LinearMath
+    )
+ELSE(PROMTS_USE_BULLET)
+    target_link_libraries(DemoPROMTSAstar
+      ${catkin_LIBRARIES}
+    )
+ENDIF(PROMTS_USE_BULLET)
 
 add_executable(DemoPROMTSDLS demo/DemoPROMTSDLS.cpp demo/DemoHelper.cpp)
-target_link_libraries(DemoPROMTSDLS
-  ${catkin_LIBRARIES} BulletDynamics  BulletCollision LinearMath
-)
+IF(PROMTS_USE_BULLET)
+    target_link_libraries(DemoPROMTSDLS
+      ${catkin_LIBRARIES} BulletDynamics  BulletCollision LinearMath
+    )
+ELSE(PROMTS_USE_BULLET)
+    target_link_libraries(DemoPROMTSDLS
+      ${catkin_LIBRARIES}
+    )
+ENDIF(PROMTS_USE_BULLET)
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries


### PR DESCRIPTION
If someone (like me) does not want to use Bullet, they can now disable compiling and linking it, saving compile time and executable size. Of course they should not try to use `rasoul::geometry::CGeometryPolyhedra::METHOD_BULLET` then, though.
